### PR TITLE
[Feature] Admin CRUD API for Lab, Checkup, and Surgery Appointments (#19)

### DIFF
--- a/server/controllers/adminController.js
+++ b/server/controllers/adminController.js
@@ -1,0 +1,51 @@
+// server/controllers/adminController.js
+const Lab = require("../models/lab");
+const Checkup = require("../models/checkup");
+const Surgery = require("../models/surgery");
+
+// Generic CRUD helpers
+const getAll = (Model) => async (req, res) => {
+  try {
+    const records = await Model.find({});
+    res.status(200).json(records);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+};
+
+const updateById = (Model) => async (req, res) => {
+  try {
+    const updated = await Model.findByIdAndUpdate(req.params.id, req.body, {
+      new: true,
+      runValidators: true,
+    });
+    if (!updated) return res.status(404).json({ message: "Not found" });
+    res.status(200).json(updated);
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+};
+
+const deleteById = (Model) => async (req, res) => {
+  try {
+    const deleted = await Model.findByIdAndDelete(req.params.id);
+    if (!deleted) return res.status(404).json({ message: "Not found" });
+    res.status(200).json({ message: "Deleted successfully" });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+};
+
+module.exports = {
+  getAllLabs: getAll(Lab),
+  updateLab: updateById(Lab),
+  deleteLab: deleteById(Lab),
+
+  getAllCheckups: getAll(Checkup),
+  updateCheckup: updateById(Checkup),
+  deleteCheckup: deleteById(Checkup),
+
+  getAllSurgeries: getAll(Surgery),
+  updateSurgery: updateById(Surgery),
+  deleteSurgery: deleteById(Surgery),
+};

--- a/server/index.js
+++ b/server/index.js
@@ -11,7 +11,7 @@ const path = require("path");
 const Surgery = require("./models/surgery");
 const authRoutes = require("./routes/authRoutes");
 const medicineRoutes = require("./routes/medicineRoutes");
-
+const adminRoutes = require("./routes/adminRoutes");
 const app = express();
 const PORT = process.env.PORT || 5000;
 
@@ -36,6 +36,7 @@ mongoose
 app.use("/uploads", express.static(path.join(__dirname, "uploads")));
 app.use("/api/auth", authRoutes);
 app.use("/api/admin/medicines", medicineRoutes);
+app.use("/api/admin", adminRoutes);
 
 app.get("/api/doctors", async (req, res) => {
   try {

--- a/server/routes/adminRoutes.js
+++ b/server/routes/adminRoutes.js
@@ -1,0 +1,37 @@
+// server/routes/adminRoutes.js
+const express = require("express");
+const router = express.Router();
+
+const {
+  getAllLabs,
+  updateLab,
+  deleteLab,
+  getAllCheckups,
+  updateCheckup,
+  deleteCheckup,
+  getAllSurgeries,
+  updateSurgery,
+  deleteSurgery,
+} = require("../controllers/adminController");
+
+const isAuthenticated = require("../middleware/isAuthenticated");
+const isAdmin = require("../middleware/isAdmin");
+
+router.use(isAuthenticated, isAdmin);
+
+// Lab
+router.get("/lab", getAllLabs);
+router.put("/lab/:id", updateLab);
+router.delete("/lab/:id", deleteLab);
+
+// Checkup
+router.get("/checkup", getAllCheckups);
+router.put("/checkup/:id", updateCheckup);
+router.delete("/checkup/:id", deleteCheckup);
+
+// Surgery
+router.get("/surgery", getAllSurgeries);
+router.put("/surgery/:id", updateSurgery);
+router.delete("/surgery/:id", deleteSurgery);
+
+module.exports = router;


### PR DESCRIPTION
Fixes #19 
Feature: Admin-only CRUD API for Managing Appointments

This pull request implements protected routes for administrators to manage all appointment records in the system, as specified in Issue #19 .

Implemented Routes:

Lab Appointments:
- GET    /api/admin/lab
- PUT    /api/admin/lab/:id
- DELETE /api/admin/lab/:id

Checkup Appointments:
- GET    /api/admin/checkup
- PUT    /api/admin/checkup/:id
- DELETE /api/admin/checkup/:id

Surgery Appointments:
- GET    /api/admin/surgery
- PUT    /api/admin/surgery/:id
- DELETE /api/admin/surgery/:id

Access Control:
- All routes are protected using JWT-based authentication middleware (`isAuthenticated`)
- Only users with role "admin" can access these routes, validated using the `isAdmin` middleware

Testing:
- All endpoints have been tested using Postman with valid and invalid tokens
- Verified proper CRUD operations and error handling for each type of appointment

This update allows admins to review, correct, or remove appointment records securely.
