### PR TITLE
added 404 error page with dark/light mode styling

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -16563,10 +16563,7 @@
       "version": "4.9.5",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
       "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-
-
       "license": "Apache-2.0",
-
       "peer": true,
       "bin": {
         "tsc": "bin/tsc",

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -1,29 +1,29 @@
-import React, { useState,useEffect } from 'react'; 
-import './components/styles.css';
-import { Routes, Route } from 'react-router-dom';
-import HomePage from './pages/HomePage';
-import PharmacyPage from './pages/PharmacyPage';
-import LabsPage from './pages/LabsPage';
-import CheckupPage from './pages/CheckupPage';
-import SurgeryPage from './pages/SurgeryPage';
-
+import React, { useState, useEffect } from "react";
+import "./components/styles.css";
+import { Routes, Route } from "react-router-dom";
+import HomePage from "./pages/HomePage";
+import PharmacyPage from "./pages/PharmacyPage";
+import LabsPage from "./pages/LabsPage";
+import CheckupPage from "./pages/CheckupPage";
+import SurgeryPage from "./pages/SurgeryPage";
+import NotFoundPage from "./pages/NotFoundPage";
 
 function App() {
   const [darkMode, setDarkMode] = useState(false);
   useEffect(() => {
-    document.body.classList.toggle('dark-mode', darkMode);
+    document.body.classList.toggle("dark-mode", darkMode);
   }, [darkMode]);
 
-
   return (
-     <Routes>
+    <Routes>
       <Route path="/" element={<HomePage />} />
       <Route path="/services/pharmacy" element={<PharmacyPage />} />
       <Route path="/services/labs-diagnostics" element={<LabsPage />} />
       <Route path="/services/checkup" element={<CheckupPage />} />
       <Route path="/services/surgery" element={<SurgeryPage />} />
+
+      <Route path="*" element={<NotFoundPage />} />
     </Routes>
-    
   );
 }
 

--- a/client/src/pages/HomePage.js
+++ b/client/src/pages/HomePage.js
@@ -13,16 +13,15 @@ import ContactSection from "../components/ContactSection";
 const Homepage = ({ darkMode, setDarkMode }) => {
   return (
     <div className={darkMode ? "dark-mode" : ""}>
-  <Navbar darkMode={darkMode} setDarkMode={setDarkMode} />
-  <Slider darkMode={darkMode} />
-  <AboutSection darkMode={darkMode} />
-  {/* <HeroSection darkMode={darkMode} /> */}
-  <ServiceSection darkMode={darkMode} />
-  <DoctorsSection darkMode={darkMode}/>      
-  <ContactSection darkMode={darkMode} />
-  <Footer />
-</div>
-
+      <Navbar darkMode={darkMode} setDarkMode={setDarkMode} />
+      <Slider darkMode={darkMode} />
+      <AboutSection darkMode={darkMode} />
+      {/* <HeroSection darkMode={darkMode} /> */}
+      <ServiceSection darkMode={darkMode} />
+      <DoctorsSection darkMode={darkMode} />
+      <ContactSection darkMode={darkMode} />
+      <Footer />
+    </div>
   );
 };
 

--- a/client/src/pages/NotFoundPage.js
+++ b/client/src/pages/NotFoundPage.js
@@ -1,0 +1,30 @@
+import React from "react";
+import styles from "./NotFoundPage.module.css";
+import { FaStethoscope } from "react-icons/fa";
+import { Link } from "react-router-dom";
+import Navbar from "../components/Navbar";
+
+function NotFoundPage() {
+  return (
+    <>
+      <Navbar />
+
+      <div className={styles.notFound}>
+        <div className={styles.content}>
+          <FaStethoscope className={styles.icon} />
+          <h1>404 - Page Not Found</h1>
+          <p className={styles.text}>
+            The page you're trying to reach doesn't exist in our hospital
+            system. It might have been moved, deleted, or you may have typed the
+            wrong URL.
+          </p>
+          <Link to="/" className={styles.homeButton}>
+            Return to Hospital Dashboard
+          </Link>
+        </div>
+      </div>
+    </>
+  );
+}
+
+export default NotFoundPage;

--- a/client/src/pages/NotFoundPage.module.css
+++ b/client/src/pages/NotFoundPage.module.css
@@ -1,0 +1,114 @@
+.notFound {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 100vh;
+    padding: 20px;
+    background-color: #ffffff;
+    box-shadow: inset 0 8px 24px #f6f5f7;
+    padding-top: 5rem;
+  }
+  
+  .content {
+    text-align: center;
+    background-color: #fdfdfd;
+    padding: 40px;
+    border-radius: 12px;
+    border: 1px solid #e2e8f0;
+    box-shadow: 0 4px 12px rgba(44, 122, 123, 0.08);
+    max-width: 500px;
+    width: 100%;
+  }
+  
+  .icon {
+    font-size: 4rem;
+    color: #13b33b;
+    margin-bottom: 20px;
+    filter: drop-shadow(0 0 4px rgba(0, 0, 0, 0.2));
+  }
+  
+  .content h1 {
+    font-size: 2.4em;
+    margin-bottom: 20px;
+    color: #203394;
+    font-weight: 700;
+  }
+  
+  .text {
+    font-size: 1.1em;
+    color: #334155;
+    margin-bottom: 30px;
+    line-height: 1.6;
+    text-align: justify;
+  }
+  
+  .homeButton {
+    display: inline-block;
+    padding: 12px 24px;
+    background-color: #203394;
+    color: #fff;
+    border-radius: 8px;
+    text-decoration: none;
+    font-weight: 600;
+    transition: background-color 0.3s ease;
+  }
+  
+  .homeButton:hover {
+    background-color: #13b33b;
+    color: #fff;
+  }
+  
+  /* Responsive Design */
+  @media (max-width: 768px) {
+    .content {
+      padding: 30px 20px;
+    }
+  
+    .icon {
+      font-size: 3rem;
+    }
+  
+    .content h1 {
+      font-size: 2em;
+    }
+  
+    .text {
+      font-size: 1em;
+    }
+  }
+  
+  /* ------------------- Dark Mode ------------------- */
+  
+  :global(body.dark-mode) .notFound {
+    background-color: #121212;
+    box-shadow: inset 0 8px 24px #000;
+  }
+  
+  :global(body.dark-mode) .content {
+    background-color: #1e1e2f;
+    border-color: #333;
+    box-shadow: 0 4px 12px rgba(255, 255, 255, 0.05);
+  }
+  
+  :global(body.dark-mode) .content h1 {
+    color: #ffffff;
+  }
+  
+  :global(body.dark-mode) .text {
+    color: #e0e0e0;
+  }
+  
+  :global(body.dark-mode) .homeButton {
+    background-color: #3c3f75;
+    color: #57d596;
+  }
+  
+  :global(body.dark-mode) .homeButton:hover {
+    background-color: #1a1f3c;
+    color: #4caf50;
+  }
+  
+  :global(body.dark-mode) .icon {
+    color: #57d596;
+  }
+  


### PR DESCRIPTION
## Description
Added a custom 404 error page that aligns with the overall website theme.
The page is responsive and visually consistent, supporting both light and dark modes using the existing theme configuration.

## screenshots
<img width="1358" height="640" alt="Screenshot from 2025-07-27 23-41-58" src="https://github.com/user-attachments/assets/709c80e5-369f-4a8e-bdda-5d599fcfaa72" />
<img width="1358" height="640" alt="Screenshot from 2025-07-27 23-42-06" src="https://github.com/user-attachments/assets/6cf48393-a169-4a2c-8e97-6a59831ce128" />
